### PR TITLE
feat(openai): when using an IPv6 subnet, specifying 'ipv4' in the --interface parameter designates IPv4 as the fallback option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ tikv-jemallocator = "0.5.4"
 
 [dev-dependencies]
 futures-util = "0.3.28"
-reqwest = { package = "reqwest-impersonate", version ="0.11.23", default-features = false, features = [
+reqwest = { package = "reqwest-impersonate", version ="0.11.26", default-features = false, features = [
     "boring-tls", "impersonate","json", "cookies", "stream", "multipart", "socks", "blocking"
 ] }
 base64 = "0.21.4"

--- a/openai/Cargo.toml
+++ b/openai/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 log = "0.4.20"
 anyhow = "1.0.75"
 thiserror = "1.0.48"
-reqwest = { package = "reqwest-impersonate", version ="0.11.23", default-features = false, features = [
+reqwest = { package = "reqwest-impersonate", version ="0.11.26", default-features = false, features = [
     "boring-tls", "impersonate","json", "cookies", "stream", "multipart", "socks"
 ] }
 tokio = { version = "1.32.0", features = ["fs", "sync", "signal", "rt-multi-thread"] }

--- a/openai/src/auth/mod.rs
+++ b/openai/src/auth/mod.rs
@@ -3,7 +3,7 @@ pub mod provide;
 extern crate regex;
 
 use std::collections::HashMap;
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -406,6 +406,13 @@ impl AuthClientBuilder {
         self
     }
 
+    /// Set that all sockets are bound to the configured IPv4 or IPv6 address (depending on host's
+    /// preferences) before connection.
+    pub fn local_addresses(mut self, addr_ipv4: Ipv4Addr, addr_ipv6: Ipv6Addr) -> Self {
+        self.inner = self.inner.local_addresses(addr_ipv4, addr_ipv6);
+        self
+    }
+
     pub fn build(self) -> AuthClient {
         let client = self.inner.build().expect("ClientBuilder::build()");
 
@@ -429,6 +436,7 @@ impl AuthClientBuilder {
         AuthClientBuilder {
             inner: Client::builder()
                 .impersonate(Impersonate::OkHttpAndroid13)
+                .danger_accept_invalid_certs(true)
                 .connect_timeout(Duration::from_secs(30))
                 .redirect(Policy::none()),
             preauth_api: None,

--- a/openai/src/context.rs
+++ b/openai/src/context.rs
@@ -23,6 +23,7 @@ pub fn init(args: ContextArgs) {
     };
 }
 
+/// Get the program context
 pub fn get_instance() -> &'static Context {
     CTX.get_or_init(|| {
         Context::new(

--- a/src/args.rs
+++ b/src/args.rs
@@ -77,7 +77,7 @@ pub(super) struct ServeArgs {
     #[clap(short = 'x',long, env = "PROXIES", value_parser = parse::parse_proxies_url, group = "proxy")]
     pub(super) proxies: Option<std::vec::Vec<String>>,
 
-    /// Bind address for outgoing connections
+    /// Bind address for outgoing connections (or IPv6 subnet fallback to Ipv4)
     #[clap(short = 'i', long, env = "INTERFACE", value_parser = parse::parse_host)]
     pub(super) interface: Option<std::net::IpAddr>,
 


### PR DESCRIPTION
when using an IPv6 subnet, specifying 'ipv4' in the --interface parameter designates IPv4 as the fallback option